### PR TITLE
Adjust menu item layout and styling for better responsiveness

### DIFF
--- a/src/components/food-order/menu/Menu.tsx
+++ b/src/components/food-order/menu/Menu.tsx
@@ -31,7 +31,7 @@ const MenuItems: TMenuItem[] = [
 
 const Menu = () => {
   return (
-    <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3">
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
       {MenuItems.map((item) => (
         <div
           key={item.id}

--- a/src/components/food-order/menu/MenuItem.tsx
+++ b/src/components/food-order/menu/MenuItem.tsx
@@ -6,9 +6,9 @@ import OrderNowButton from "./OrderNowButton.2";
 
 const MenuItem = ({ id, title, description, price, image }: TMenuItem) => {
   return (
-    <article className="relative flex h-[498px] w-full max-w-xs flex-col items-center rounded-2xl bg-gradient-to-b from-white from-40% to-primary/10 shadow-lg transition-transform duration-300 hover:scale-[1.02] hover:shadow-xl  md:max-w-sm">
+    <article className="relative flex h-[400px] w-[80%] max-w-xs flex-col items-center rounded-2xl bg-gradient-to-b from-white from-40% to-primary/10 shadow-lg transition-transform duration-300 hover:scale-[1.02] hover:shadow-xl  md:max-w-sm">
       {/* Image Section with Gradient Border */}
-      <div className="relative  aspect-square w-[80%] min-w-[140px]">
+      <div className="relative  aspect-square w-[70%] min-w-[140px]">
         <div className="absolute inset-0 rounded-full bg-[linear-gradient(to_bottom,#F54748_0%,#FDC55E_50%,transparent_50%)] p-[3px] sm:p-1.5">
           <div className="relative h-full w-full overflow-hidden rounded-full border-2 border-white md:border-[3px]">
             <Image
@@ -23,26 +23,26 @@ const MenuItem = ({ id, title, description, price, image }: TMenuItem) => {
         </div>
 
         {/* Price Badge with Fluid Typography */}
-        <div className="absolute right-[5%] bottom-[10%] z-10 flex aspect-square w-[25%] min-w-[60px] items-center justify-center rounded-full border-2 border-white bg-[#FDC55E] text-[clamp(0.65rem,2vw,1rem)] font-bold text-white shadow-md sm:right-[7%] sm:bottom-[10%] md:text-[clamp(0.75rem,1.5vw,1.1rem)]">
+        <div
+          className="absolute right-[5%] bottom-[10%] z-10 flex aspect-square w-[30%] min-w-[60px] items-center justify-center rounded-full border-2 border-white bg-[#FDC55E] text-[clamp(0.60rem,2vw,0.90rem)] font-bold text-white
+        shadow-md sm:right-[7%] sm:bottom-[10%] md:text-[clamp(0.65rem,1.5vw,0.95rem)]"
+        >
           <span>{formatCurrency(price)}</span>
         </div>
       </div>
 
       {/* Content Section */}
-      <div className="flex flex-1 flex-col items-center px-4 py-2 sm:px-6 sm:py-4">
-        {/* Text Content */}
-        <div className="mb-2 flex flex-1 flex-col items-center justify-center sm:mb-4">
-          <h2 className="text-center text-lg font-bold text-primary sm:text-xl md:text-2xl">
-            {title}
-          </h2>
-          <p className="line-clamp-3 mt-1 text-xs text-gray-600 sm:mt-2 sm:text-sm md:text-base">
-            {description}
-          </p>
-        </div>
+      <div className="flex flex-1 flex-col text-center px-4 py-2 sm:px-6 sm:py-4">
+        <h2 className="text-lg font-bold text-primary sm:text-xl md:text-2xl">
+          {title}
+        </h2>
+        <p className="line-clamp-3 mt-1 text-xs text-gray-600 sm:mt-2 sm:text-sm md:text-base">
+          {description}
+        </p>
       </div>
 
       {/* Floating Action Button */}
-      <OrderNowButton item={{id, title, description, price, image}} />
+      <OrderNowButton item={{ id, title, description, price, image }} />
     </article>
   );
 };


### PR DESCRIPTION
- Reduce grid gap in the menu layout from `gap-8` to `gap-4` for better spacing.
- Adjust height and width of menu items to `h-[400px]` and `w-[80%]` for improved proportions.
- Decrease image container width to `w-[70%]` for better visual balance.
- Modify price badge text size to `text-[clamp(0.60rem,2vw,0.90rem)]` for consistency.
- Simplify content section by removing unnecessary nested divs and centering text directly.
- Fix spacing in `OrderNowButton` props for cleaner code formatting.

These changes enhance the overall responsiveness and visual appeal of the menu items.